### PR TITLE
Add regional email changes

### DIFF
--- a/spec/json/tsg_domain_authentication_v3.json
+++ b/spec/json/tsg_domain_authentication_v3.json
@@ -213,6 +213,10 @@
                   "custom_dkim_selector": {
                     "type": "string",
                     "description": "Add a custom DKIM selector. Accepts three letters or numbers."
+                  },
+                  "region": {
+                    "type": "string",
+                    "description": "The region of the domain. Allowed values are `global` and `eu`. The default value is `global`."
                   }
                 },
                 "required": [
@@ -228,7 +232,9 @@
                   ],
                   "custom_spf": true,
                   "default": true,
-                  "automatic_security": false
+                  "automatic_security": false,
+                  "custom_dkim_selector": "string",
+                  "region": "global"
                 }
               }
             }

--- a/spec/json/tsg_ip_address_management_v3.json
+++ b/spec/json/tsg_ip_address_management_v3.json
@@ -69,7 +69,7 @@
                           },
                           "is_auto_warmup": {
                             "type": "boolean",
-                            "description": "Indicates if the IP address is set to automatically [warmup](https://docs.sendgrid.com/ui/sending-email/warming-up-an-ip-address). This parameter is returned only if the IP address is set to automatically warm up."
+                            "description": "Indicates if the IP address is set to automatically [warmup](https://docs.sendgrid.com/ui/sending-email/warming-up-an-ip-address)."
                           },
                           "is_parent_assigned": {
                             "type": [
@@ -99,6 +99,14 @@
                           "added_at": {
                             "type": "integer",
                             "description": "A timestamp representing when the IP address was added to your account."
+                          },
+                          "region": {
+                            "type": "string",
+                            "description": "The region to which the IP address is assigned. This property will only be returned if the `include_region` query parameter is included and set to `true` as part of the API request.",
+                            "enum": [
+                              "eu",
+                              "us"
+                            ]
                           }
                         }
                       }
@@ -106,51 +114,69 @@
                     "_metadata": {
                       "type": "object",
                       "properties": {
-                        "after_key": {
-                          "type": [
-                            "string",
-                            "null"
-                          ],
-                          "description": "Specifies which items to be returned by the API. When the `after_key` is specified, the API will return items beginning from the first item after the item specified. This parameter can be used in combination with `limit` to iterate through paginated results. The `after_key` cannot be used in combination with the `before_key` parameter."
-                        },
-                        "before_key": {
-                          "type": [
-                            "string",
-                            "null"
-                          ],
-                          "description": "Specifies which items to be returned by the API. When the `before_key` is specified, the API will return items beginning from the first item before the item specified. This parameter can be used in combination with `limit` to iterate through paginated results. The `before_key` cannot be used in combination with the `after_key` parameter."
-                        },
-                        "ip": {
-                          "type": "string",
-                          "description": "The IP address specified in the request with the `ip` query parameter. This parameter is returned only when an IP is included in the request."
-                        },
-                        "is_leased": {
-                          "type": "boolean",
-                          "description": "Indicates whether an IP address is leased from Twilio SendGrid. If `false`, the IP address is not a Twilio SendGrid IP; it is a customer's own IP that has been added to their Twilio SendGrid account. This parameter is returned only if the IP address is leased."
-                        },
-                        "is_enabled": {
-                          "type": "boolean",
-                          "description": "Indicates if the IP address is billed and able to send email. This parameter applies to non-Twilio SendGrid APIs that been added to your Twilio SendGrid account. This parameter's value is `null` for Twilio SendGrid IP addresses. This parameter is returned only if the IP address is enabled."
-                        },
-                        "is_parent_assigned": {
-                          "type": "boolean",
-                          "description": "Indicates if a parent on the account is able to send email from the IP address. This parameter is returned only if the IP address is parent assigned."
-                        },
-                        "pool": {
-                          "type": "string",
-                          "description": "The IP Pool ID specified in the request with the `pool` query parameter. This paramerter is returned only when an IP Pool is included in the request."
-                        },
-                        "start_added_at": {
-                          "type": "string",
-                          "description": "The beginning of the time window specified in the request with the `start_added_at` query parameter. This parameter is returned only when the `start_added_at` parameter is included in the request."
-                        },
-                        "end_added_at": {
-                          "type": "string",
-                          "description": "The end of the time window specified in the request with the `end_added_at` query parameter. This parameter is returned only when the `end_added_at` parameter is included in the request."
-                        },
-                        "limit": {
-                          "type": "string",
-                          "description": "The number of items returned in the request. This parameter is returned only when a `limit` is set using the `limit` query parameter in the request."
+                        "next_params": {
+                          "type": "object",
+                          "properties": {
+                            "after_key": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "Specifies which items to be returned by the API. When the `after_key` is specified, the API will return items beginning from the first item after the item specified. This parameter can be used in combination with `limit` to iterate through paginated results. The `after_key` cannot be used in combination with the `before_key` parameter."
+                            },
+                            "before_key": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "Specifies which items to be returned by the API. When the `before_key` is specified, the API will return items beginning from the first item before the item specified. This parameter can be used in combination with `limit` to iterate through paginated results. The `before_key` cannot be used in combination with the `after_key` parameter."
+                            },
+                            "ip": {
+                              "type": "string",
+                              "description": "The IP address specified in the request with the `ip` query parameter. This parameter is returned only when an IP is included in the request."
+                            },
+                            "is_leased": {
+                              "type": "boolean",
+                              "description": "Indicates whether an IP address is leased from Twilio SendGrid. If `false`, the IP address is not a Twilio SendGrid IP; it is a customer's own IP that has been added to their Twilio SendGrid account. This parameter is returned only if the IP address is leased."
+                            },
+                            "is_enabled": {
+                              "type": "boolean",
+                              "description": "Indicates if the IP address is billed and able to send email. This parameter applies to non-Twilio SendGrid APIs that been added to your Twilio SendGrid account. This parameter's value is `null` for Twilio SendGrid IP addresses. This parameter is returned only if the IP address is enabled."
+                            },
+                            "is_parent_assigned": {
+                              "type": "boolean",
+                              "description": "Indicates if a parent on the account is able to send email from the IP address. This parameter is returned only if the IP address is parent assigned."
+                            },
+                            "pool": {
+                              "type": "string",
+                              "description": "The IP Pool ID specified in the request with the `pool` query parameter. This parameter is returned only when an IP Pool is included in the request."
+                            },
+                            "start_added_at": {
+                              "type": "string",
+                              "description": "The beginning of the time window specified in the request with the `start_added_at` query parameter. This parameter is returned only when the `start_added_at` parameter is included in the request."
+                            },
+                            "end_added_at": {
+                              "type": "string",
+                              "description": "The end of the time window specified in the request with the `end_added_at` query parameter. This parameter is returned only when the `end_added_at` parameter is included in the request."
+                            },
+                            "limit": {
+                              "type": "string",
+                              "description": "The number of items returned in the request. This parameter is returned only when a `limit` is set using the `limit` query parameter in the request."
+                            },
+                            "region": {
+                              "type": "string",
+                              "description": "The region to which the IP address is assigned. This property will only be returned if the `include_region` query parameter is included and set to `true` as part of the API request,",
+                              "enum": [
+                                "all",
+                                "us",
+                                "eu"
+                              ]
+                            },
+                            "include_region": {
+                              "type": "string",
+                              "description": "Indicates whether or not to include the IP address's region. This property will only be returned if the `include_region` query parameter is included and set to `true` as part of the API request."
+                            }
+                          }
                         }
                       }
                     }
@@ -173,7 +199,8 @@
                           "updated_at": null,
                           "is_enabled": true,
                           "is_leased": true,
-                          "added_at": 1664390835
+                          "added_at": 1664390835,
+                          "region": "us"
                         }
                       ],
                       "_metadata": {
@@ -290,6 +317,12 @@
           },
           {
             "$ref": "#/components/parameters/IpAddressManagementEndAddedAt"
+          },
+          {
+            "$ref": "#/components/parameters/IpAddressManagementRegion"
+          },
+          {
+            "$ref": "#/components/parameters/IpAddressManagementIncludeRegion"
           }
         ]
       },
@@ -325,6 +358,14 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "region": {
+                      "type": "string",
+                      "description": "The region to which the IP address is assigned. This property will only be returned if the `include_region` query parameter is included and set to `true` as part of the API request.",
+                      "enum": [
+                        "eu",
+                        "us"
+                      ]
                     }
                   }
                 },
@@ -408,6 +449,20 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "region": {
+                    "type": "string",
+                    "default": "us",
+                    "description": "The region to which the IP address is assigned. This property will only be returned if the `include_region` query parameter is included and set to `true` as part of the API request.",
+                    "enum": [
+                      "eu",
+                      "us"
+                    ]
+                  },
+                  "include_region": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Boolean indicating whether or not to return the IP address's region information in the response. (Regional email is in Public Beta and requires SendGrid Pro plan or above.)"
                   }
                 },
                 "required": [
@@ -437,6 +492,11 @@
         "tags": [
           "IP Address Management"
         ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IpAddressManagementIncludeRegion"
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -451,11 +511,11 @@
                     },
                     "is_parent_assigned": {
                       "type": "boolean",
-                      "description": "Indicates if a parent on the account is able to send email from the IP address. This parameter is returned only if the IP address is parent assigned."
+                      "description": "Indicates if a parent on the account is able to send email from the IP address."
                     },
                     "is_auto_warmup": {
                       "type": "boolean",
-                      "description": "Indicates if the IP address is set to automatically [warmup](https://docs.sendgrid.com/ui/sending-email/warming-up-an-ip-address). This parameter is returned only if the IP address is set to automatically warm up."
+                      "description": "Indicates if the IP address is set to automatically [warmup](https://docs.sendgrid.com/ui/sending-email/warming-up-an-ip-address)."
                     },
                     "pools": {
                       "type": "array",
@@ -495,6 +555,10 @@
                     "is_leased": {
                       "type": "boolean",
                       "description": "Indicates whether an IP address is leased from Twilio SendGrid. If `false`, the IP address is not a Twilio SendGrid IP; it is a customer's own IP that has been added to their Twilio SendGrid account."
+                    },
+                    "region": {
+                      "type": "string",
+                      "description": "The region to which the IP address is assigned. This property will only be returned if the `include_region` query parameter is included and set to `true` as part of the API request. Possible values are `us` or `eu`."
                     }
                   }
                 },
@@ -513,7 +577,8 @@
                       "added_at": 1664390835,
                       "updated_at": null,
                       "is_enabled": true,
-                      "is_leased": true
+                      "is_leased": true,
+                      "region": "us"
                     }
                   }
                 }
@@ -573,7 +638,7 @@
                     },
                     "is_auto_warmup": {
                       "type": "boolean",
-                      "description": "Indicates if the IP address is set to automatically [warmup](https://docs.sendgrid.com/ui/sending-email/warming-up-an-ip-address). This parameter is returned only if the IP address is set to automatically warm up."
+                      "description": "Indicates if the IP address is set to automatically [warmup](https://docs.sendgrid.com/ui/sending-email/warming-up-an-ip-address)."
                     },
                     "is_parent_assigned": {
                       "type": "boolean",
@@ -1001,6 +1066,12 @@
           },
           {
             "$ref": "#/components/parameters/IpAddressManagementQueryIp"
+          },
+          {
+            "$ref": "#/components/parameters/IpAddressManagementRegion"
+          },
+          {
+            "$ref": "#/components/parameters/IpAddressManagementIncludeRegion"
           }
         ],
         "responses": {
@@ -1023,6 +1094,17 @@
                           "id": {
                             "type": "string",
                             "description": "The unique ID of the IP Pool."
+                          },
+                          "regions": {
+                            "type": "array",
+                            "description": "An array of the unique regions of all the IP addresses returned within the IP pool.",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "eu",
+                                "us"
+                              ]
+                            }
                           },
                           "ips_preview": {
                             "type": "array",
@@ -1060,6 +1142,19 @@
                             "limit": {
                               "type": "string",
                               "description": "The `limit` specified in the request. This parameter will be included only if it was specified in the request. This is not the default limit enforced by the API."
+                            },
+                            "region": {
+                              "type": "string",
+                              "description": "The region to which the IP address is assigned. This property will only be returned if the `include_region` query parameter is included and set to `true` as part of the API request.",
+                              "enum": [
+                                "all",
+                                "us",
+                                "eu"
+                              ]
+                            },
+                            "include_region": {
+                              "type": "string",
+                              "description": "Indicates whether or not to include the IP address's region. This property will only be returned if the `include_region` query parameter is included and set to `true` as part of the API request."
                             }
                           }
                         }
@@ -1282,6 +1377,11 @@
           "IP Address Management"
         ],
         "operationId": "GetSendIpsPools",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IpAddressManagementIncludeRegion"
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1308,6 +1408,27 @@
                     "total_ip_count": {
                       "description": "The total number of IP addresses in the IP Pool. An IP Pool can have a maximum of 100 associated IP addresses.",
                       "type": "integer"
+                    },
+                    "ip_count_by_region": {
+                      "type": "array",
+                      "description": "The total number of IP addresses by region. this object is only returned if the `include_region` parameter is included and set to `true` in the API request.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "region": {
+                            "type": "string",
+                            "description": "The region associated with the number of IPs listed in the `count` property.",
+                            "enum": [
+                              "us",
+                              "eu"
+                            ]
+                          },
+                          "count": {
+                            "type": "integer",
+                            "description": "The number of IP addresses in the pool that are assigned to the region specified in the `region` property for this count."
+                          }
+                        }
+                      }
                     }
                   }
                 },
@@ -1517,6 +1638,14 @@
                             "type": "string",
                             "description": "An IP address assigned to the IP Pool."
                           },
+                          "region": {
+                            "type": "string",
+                            "description": "The region to which the IP address is assigned. This property will only be returned if the `include_region` query parameter is included and set to `true` as part of the API request.",
+                            "enum": [
+                              "eu",
+                              "us"
+                            ]
+                          },
                           "pools": {
                             "type": "array",
                             "description": "IP Pools the IP address is assigned to.",
@@ -1554,6 +1683,10 @@
                             "limit": {
                               "type": "string",
                               "description": "The `limit` specified in the request. This parameter will be included only if it was specified in the request. This is not the default limit enforced by the API."
+                            },
+                            "include_region": {
+                              "type": "string",
+                              "description": "Indicates whether or not to include the IP address's region. This property will only be returned if the `include_region` query parameter is included and set to `true` as part of the API request."
                             }
                           }
                         }
@@ -1622,6 +1755,9 @@
           },
           {
             "$ref": "#/components/parameters/IpAddressManagementAfterKey"
+          },
+          {
+            "$ref": "#/components/parameters/IpAddressManagementIncludeRegion"
           }
         ]
       },
@@ -2030,7 +2166,7 @@
         "schema": {
           "type": "string"
         },
-        "description": "Specifices an IP address. The `ip` query parameter can be used to filter results by IP address."
+        "description": "Specifies an IP address. The `ip` query parameter can be used to filter results by IP address."
       },
       "IpAddressManagementBeforeKey": {
         "name": "before_key",
@@ -2066,7 +2202,7 @@
         "schema": {
           "type": "boolean"
         },
-        "description": "Indicates if a parent on the account is able to send email from the IP address. When set to `true`, only enabled IP addresses will be returned."
+        "description": "A parent must be assigned to an IP address before the parent can send mail from the IP and before the address can be assigned to an IP pool. Set this parameter value to true to allow the parent to send mail from the IP and make the IP eligible for IP pool assignment using the IP pool endpoints."
       },
       "IpAddressManagementPool": {
         "name": "pool",
@@ -2093,7 +2229,31 @@
         "schema": {
           "type": "integer"
         },
-        "description": "The `start_added_at` and `end_added_at` parameters are used to set a time window. IP addresses that were added to your account in the specified time window will be returned. The `start_added_at` parameter sets the end of the time window."
+        "description": "The `start_added_at` and `end_added_at` parameters are used to set a time window. IP addresses that were added to your account in the specified time window will be returned. The `end_added_at` parameter sets the end of the time window."
+      },
+      "IpAddressManagementRegion": {
+        "name": "region",
+        "in": "query",
+        "required": false,
+        "description": "Allowed values are `all`, `eu`, and `us`. If you provide a specific region, results will include all pools that have at least one IP in the filtered region. If `all`, pools with at least one IP (regardless of region) will be returned. If the `region` filter is not provided, the query returns all pools, including empty ones. (Regional email is in Public Beta and requires SendGrid Pro plan or above.)",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "all",
+            "eu",
+            "us"
+          ]
+        }
+      },
+      "IpAddressManagementIncludeRegion": {
+        "name": "include_region",
+        "in": "query",
+        "required": false,
+        "description": "Boolean indicating whether or not to return the IP Pool's region information in the response. (Regional email is in Public Beta and requires SendGrid Pro plan or above.)",
+        "schema": {
+          "type": "boolean",
+          "default": false
+        }
       }
     },
     "examples": {

--- a/spec/json/tsg_link_branding_v3.json
+++ b/spec/json/tsg_link_branding_v3.json
@@ -61,6 +61,15 @@
                       true,
                       false
                     ]
+                  },
+                  "region": {
+                    "type": "string",
+                    "default": "us",
+                    "description": "The region of the IP address. Can be `eu` or `us`. (Regional email is in Public Beta and requires SendGrid Pro plan or above.)",
+                    "enum": [
+                      "eu",
+                      "us"
+                    ]
                   }
                 },
                 "required": [

--- a/spec/json/tsg_subusers_v3.json
+++ b/spec/json/tsg_subusers_v3.json
@@ -53,6 +53,29 @@
             }
           },
           {
+            "name": "region",
+            "in": "query",
+            "description": "Filter for Subusers in this region. If not provided, all Subusers will be returned. All users can also be explicitly requested by using the filter `all`. Users who are not pinned to a region will be displayed as `global`. (Regional email is in Public Beta and requires SendGrid Pro plan or above.)",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "all",
+                "global",
+                "eu"
+              ],
+              "default": "all"
+            }
+          },
+          {
+            "name": "include_region",
+            "in": "query",
+            "description": "Optional flag to include the regions of the Subusers in the response. If not provided, the region will be omitted from the response. (Regional email is in Public Beta and requires SendGrid Pro plan or above.)",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
             "$ref": "#/components/parameters/PaginationCommonOffset"
           }
         ],
@@ -145,6 +168,20 @@
                       "type": "string",
                       "format": "ipv4"
                     }
+                  },
+                  "region": {
+                    "type": "string",
+                    "description": "The region this Subuser should be assigned to. Can be `global` or `eu`. (Regional email is in Public Beta and requires SendGrid Pro plan or above.).",
+                    "enum": [
+                      "global",
+                      "eu"
+                    ],
+                    "default": "global"
+                  },
+                  "include_region": {
+                    "type": "boolean",
+                    "description": "A flag that determines if the Subuser's region should be returned in the response. (Regional email is in Public Beta and requires SendGrid Pro plan or above.)",
+                    "default": false
                   }
                 },
                 "required": [
@@ -160,7 +197,9 @@
                   "ips": [
                     "1.1.1.1",
                     "2.2.2.2"
-                  ]
+                  ],
+                  "region": "global",
+                  "include_region": true
                 }
               }
             }
@@ -1545,6 +1584,14 @@
             "type": "string",
             "description": "The email address to contact this subuser.",
             "format": "email"
+          },
+          "region": {
+            "type": "string",
+            "description": "The region this Subuser is assigned to. This property is returned only if the `include_region` parameter was included and set to `true` in the API request.",
+            "enum": [
+              "global",
+              "eu"
+            ]
           }
         },
         "required": [
@@ -1584,6 +1631,15 @@
                 "type": "string"
               }
             }
+          },
+          "region": {
+            "type": "string",
+            "description": "The region this Subuser is assigned to. The property is returned only if the `include_region` parameter is included and set to `true` in the API request.",
+            "enum": [
+              "global",
+              "eu"
+            ],
+            "default": "global"
           }
         },
         "required": [
@@ -1597,7 +1653,8 @@
           "email": "example@example.com",
           "credit_allocation": {
             "type": "unlimited"
-          }
+          },
+          "region": "global"
         }
       },
       "SubuserCredits": {

--- a/spec/yaml/tsg_domain_authentication_v3.yaml
+++ b/spec/yaml/tsg_domain_authentication_v3.yaml
@@ -203,6 +203,10 @@ paths:
                   type: string
                   description: Add a custom DKIM selector. Accepts three letters or
                     numbers.
+                region:
+                  type: string
+                  description: The region of the domain. Allowed values are `global`
+                    and `eu`. The default value is `global`.
               required:
               - domain
               example:
@@ -215,6 +219,8 @@ paths:
                 custom_spf: true
                 default: true
                 automatic_security: false
+                custom_dkim_selector: string
+                region: global
       responses:
         '201':
           description: ''

--- a/spec/yaml/tsg_ip_address_management_v3.yaml
+++ b/spec/yaml/tsg_ip_address_management_v3.yaml
@@ -62,8 +62,6 @@ paths:
                           type: boolean
                           description: Indicates if the IP address is set to automatically
                             [warmup](https://docs.sendgrid.com/ui/sending-email/warming-up-an-ip-address).
-                            This parameter is returned only if the IP address is set
-                            to automatically warm up.
                         is_parent_assigned:
                           type:
                           - boolean
@@ -97,75 +95,107 @@ paths:
                           type: integer
                           description: A timestamp representing when the IP address
                             was added to your account.
+                        region:
+                          type: string
+                          description: The region to which the IP address is assigned.
+                            This property will only be returned if the `include_region`
+                            query parameter is included and set to `true` as part
+                            of the API request.
+                          enum:
+                          - eu
+                          - us
                   _metadata:
                     type: object
                     properties:
-                      after_key:
-                        type:
-                        - string
-                        - 'null'
-                        description: Specifies which items to be returned by the API.
-                          When the `after_key` is specified, the API will return items
-                          beginning from the first item after the item specified.
-                          This parameter can be used in combination with `limit` to
-                          iterate through paginated results. The `after_key` cannot
-                          be used in combination with the `before_key` parameter.
-                      before_key:
-                        type:
-                        - string
-                        - 'null'
-                        description: Specifies which items to be returned by the API.
-                          When the `before_key` is specified, the API will return
-                          items beginning from the first item before the item specified.
-                          This parameter can be used in combination with `limit` to
-                          iterate through paginated results. The `before_key` cannot
-                          be used in combination with the `after_key` parameter.
-                      ip:
-                        type: string
-                        description: The IP address specified in the request with
-                          the `ip` query parameter. This parameter is returned only
-                          when an IP is included in the request.
-                      is_leased:
-                        type: boolean
-                        description: Indicates whether an IP address is leased from
-                          Twilio SendGrid. If `false`, the IP address is not a Twilio
-                          SendGrid IP; it is a customer's own IP that has been added
-                          to their Twilio SendGrid account. This parameter is returned
-                          only if the IP address is leased.
-                      is_enabled:
-                        type: boolean
-                        description: Indicates if the IP address is billed and able
-                          to send email. This parameter applies to non-Twilio SendGrid
-                          APIs that been added to your Twilio SendGrid account. This
-                          parameter's value is `null` for Twilio SendGrid IP addresses.
-                          This parameter is returned only if the IP address is enabled.
-                      is_parent_assigned:
-                        type: boolean
-                        description: Indicates if a parent on the account is able
-                          to send email from the IP address. This parameter is returned
-                          only if the IP address is parent assigned.
-                      pool:
-                        type: string
-                        description: The IP Pool ID specified in the request with
-                          the `pool` query parameter. This paramerter is returned
-                          only when an IP Pool is included in the request.
-                      start_added_at:
-                        type: string
-                        description: The beginning of the time window specified in
-                          the request with the `start_added_at` query parameter. This
-                          parameter is returned only when the `start_added_at` parameter
-                          is included in the request.
-                      end_added_at:
-                        type: string
-                        description: The end of the time window specified in the request
-                          with the `end_added_at` query parameter. This parameter
-                          is returned only when the `end_added_at` parameter is included
-                          in the request.
-                      limit:
-                        type: string
-                        description: The number of items returned in the request.
-                          This parameter is returned only when a `limit` is set using
-                          the `limit` query parameter in the request.
+                      next_params:
+                        type: object
+                        properties:
+                          after_key:
+                            type:
+                            - string
+                            - 'null'
+                            description: Specifies which items to be returned by the
+                              API. When the `after_key` is specified, the API will
+                              return items beginning from the first item after the
+                              item specified. This parameter can be used in combination
+                              with `limit` to iterate through paginated results. The
+                              `after_key` cannot be used in combination with the `before_key`
+                              parameter.
+                          before_key:
+                            type:
+                            - string
+                            - 'null'
+                            description: Specifies which items to be returned by the
+                              API. When the `before_key` is specified, the API will
+                              return items beginning from the first item before the
+                              item specified. This parameter can be used in combination
+                              with `limit` to iterate through paginated results. The
+                              `before_key` cannot be used in combination with the
+                              `after_key` parameter.
+                          ip:
+                            type: string
+                            description: The IP address specified in the request with
+                              the `ip` query parameter. This parameter is returned
+                              only when an IP is included in the request.
+                          is_leased:
+                            type: boolean
+                            description: Indicates whether an IP address is leased
+                              from Twilio SendGrid. If `false`, the IP address is
+                              not a Twilio SendGrid IP; it is a customer's own IP
+                              that has been added to their Twilio SendGrid account.
+                              This parameter is returned only if the IP address is
+                              leased.
+                          is_enabled:
+                            type: boolean
+                            description: Indicates if the IP address is billed and
+                              able to send email. This parameter applies to non-Twilio
+                              SendGrid APIs that been added to your Twilio SendGrid
+                              account. This parameter's value is `null` for Twilio
+                              SendGrid IP addresses. This parameter is returned only
+                              if the IP address is enabled.
+                          is_parent_assigned:
+                            type: boolean
+                            description: Indicates if a parent on the account is able
+                              to send email from the IP address. This parameter is
+                              returned only if the IP address is parent assigned.
+                          pool:
+                            type: string
+                            description: The IP Pool ID specified in the request with
+                              the `pool` query parameter. This parameter is returned
+                              only when an IP Pool is included in the request.
+                          start_added_at:
+                            type: string
+                            description: The beginning of the time window specified
+                              in the request with the `start_added_at` query parameter.
+                              This parameter is returned only when the `start_added_at`
+                              parameter is included in the request.
+                          end_added_at:
+                            type: string
+                            description: The end of the time window specified in the
+                              request with the `end_added_at` query parameter. This
+                              parameter is returned only when the `end_added_at` parameter
+                              is included in the request.
+                          limit:
+                            type: string
+                            description: The number of items returned in the request.
+                              This parameter is returned only when a `limit` is set
+                              using the `limit` query parameter in the request.
+                          region:
+                            type: string
+                            description: The region to which the IP address is assigned.
+                              This property will only be returned if the `include_region`
+                              query parameter is included and set to `true` as part
+                              of the API request,
+                            enum:
+                            - all
+                            - us
+                            - eu
+                          include_region:
+                            type: string
+                            description: Indicates whether or not to include the IP
+                              address's region. This property will only be returned
+                              if the `include_region` query parameter is included
+                              and set to `true` as part of the API request.
               examples:
                 '200':
                   value:
@@ -180,6 +210,7 @@ paths:
                       is_enabled: true
                       is_leased: true
                       added_at: 1664390835
+                      region: us
                     _metadata:
                       after_key: null
                       before_key: null
@@ -255,6 +286,8 @@ paths:
       - $ref: '#/components/parameters/IpAddressManagementPool'
       - $ref: '#/components/parameters/IpAddressManagementStartAddedAt'
       - $ref: '#/components/parameters/IpAddressManagementEndAddedAt'
+      - $ref: '#/components/parameters/IpAddressManagementRegion'
+      - $ref: '#/components/parameters/IpAddressManagementIncludeRegion'
     post:
       summary: Add a Twilio SendGrid IP Address
       tags:
@@ -287,6 +320,14 @@ paths:
                       to.
                     items:
                       type: string
+                  region:
+                    type: string
+                    description: The region to which the IP address is assigned. This
+                      property will only be returned if the `include_region` query
+                      parameter is included and set to `true` as part of the API request.
+                    enum:
+                    - eu
+                    - us
               examples:
                 '201':
                   value:
@@ -345,6 +386,21 @@ paths:
                     to.
                   items:
                     type: string
+                region:
+                  type: string
+                  default: us
+                  description: The region to which the IP address is assigned. This
+                    property will only be returned if the `include_region` query parameter
+                    is included and set to `true` as part of the API request.
+                  enum:
+                  - eu
+                  - us
+                include_region:
+                  type: boolean
+                  default: false
+                  description: Boolean indicating whether or not to return the IP
+                    address's region information in the response. (Regional email
+                    is in Public Beta and requires SendGrid Pro plan or above.)
               required:
               - is_auto_warmup
               - is_parent_assigned
@@ -360,6 +416,8 @@ paths:
       summary: Get Details for an IP Address
       tags:
       - IP Address Management
+      parameters:
+      - $ref: '#/components/parameters/IpAddressManagementIncludeRegion'
       responses:
         '200':
           description: OK
@@ -374,14 +432,11 @@ paths:
                   is_parent_assigned:
                     type: boolean
                     description: Indicates if a parent on the account is able to send
-                      email from the IP address. This parameter is returned only if
-                      the IP address is parent assigned.
+                      email from the IP address.
                   is_auto_warmup:
                     type: boolean
                     description: Indicates if the IP address is set to automatically
                       [warmup](https://docs.sendgrid.com/ui/sending-email/warming-up-an-ip-address).
-                      This parameter is returned only if the IP address is set to
-                      automatically warm up.
                   pools:
                     type: array
                     description: An array of IP Pools the IP address is assigned to.
@@ -417,6 +472,12 @@ paths:
                       SendGrid. If `false`, the IP address is not a Twilio SendGrid
                       IP; it is a customer's own IP that has been added to their Twilio
                       SendGrid account.
+                  region:
+                    type: string
+                    description: The region to which the IP address is assigned. This
+                      property will only be returned if the `include_region` query
+                      parameter is included and set to `true` as part of the API request.
+                      Possible values are `us` or `eu`.
               examples:
                 '200':
                   value:
@@ -430,6 +491,7 @@ paths:
                     updated_at: null
                     is_enabled: true
                     is_leased: true
+                    region: us
         '400':
           description: Bad Request
           content:
@@ -474,8 +536,6 @@ paths:
                     type: boolean
                     description: Indicates if the IP address is set to automatically
                       [warmup](https://docs.sendgrid.com/ui/sending-email/warming-up-an-ip-address).
-                      This parameter is returned only if the IP address is set to
-                      automatically warm up.
                   is_parent_assigned:
                     type: boolean
                     description: Indicates if a parent on the account is able to send
@@ -788,6 +848,8 @@ paths:
       - $ref: '#/components/parameters/IpAddressManagementLimit'
       - $ref: '#/components/parameters/IpAddressManagementAfterKey'
       - $ref: '#/components/parameters/IpAddressManagementQueryIp'
+      - $ref: '#/components/parameters/IpAddressManagementRegion'
+      - $ref: '#/components/parameters/IpAddressManagementIncludeRegion'
       responses:
         '200':
           description: OK
@@ -807,6 +869,15 @@ paths:
                         id:
                           type: string
                           description: The unique ID of the IP Pool.
+                        regions:
+                          type: array
+                          description: An array of the unique regions of all the IP
+                            addresses returned within the IP pool.
+                          items:
+                            type: string
+                            enum:
+                            - eu
+                            - us
                         ips_preview:
                           type: array
                           maxItems: 10
@@ -849,6 +920,22 @@ paths:
                               parameter will be included only if it was specified
                               in the request. This is not the default limit enforced
                               by the API.
+                          region:
+                            type: string
+                            description: The region to which the IP address is assigned.
+                              This property will only be returned if the `include_region`
+                              query parameter is included and set to `true` as part
+                              of the API request.
+                            enum:
+                            - all
+                            - us
+                            - eu
+                          include_region:
+                            type: string
+                            description: Indicates whether or not to include the IP
+                              address's region. This property will only be returned
+                              if the `include_region` query parameter is included
+                              and set to `true` as part of the API request.
               examples:
                 '200':
                   value:
@@ -992,6 +1079,8 @@ paths:
       tags:
       - IP Address Management
       operationId: GetSendIpsPools
+      parameters:
+      - $ref: '#/components/parameters/IpAddressManagementIncludeRegion'
       responses:
         '200':
           description: OK
@@ -1016,6 +1105,26 @@ paths:
                     description: The total number of IP addresses in the IP Pool.
                       An IP Pool can have a maximum of 100 associated IP addresses.
                     type: integer
+                  ip_count_by_region:
+                    type: array
+                    description: The total number of IP addresses by region. this
+                      object is only returned if the `include_region` parameter is
+                      included and set to `true` in the API request.
+                    items:
+                      type: object
+                      properties:
+                        region:
+                          type: string
+                          description: The region associated with the number of IPs
+                            listed in the `count` property.
+                          enum:
+                          - us
+                          - eu
+                        count:
+                          type: integer
+                          description: The number of IP addresses in the pool that
+                            are assigned to the region specified in the `region` property
+                            for this count.
               examples:
                 '200':
                   value:
@@ -1162,6 +1271,15 @@ paths:
                         ip:
                           type: string
                           description: An IP address assigned to the IP Pool.
+                        region:
+                          type: string
+                          description: The region to which the IP address is assigned.
+                            This property will only be returned if the `include_region`
+                            query parameter is included and set to `true` as part
+                            of the API request.
+                          enum:
+                          - eu
+                          - us
                         pools:
                           type: array
                           description: IP Pools the IP address is assigned to.
@@ -1199,6 +1317,12 @@ paths:
                               parameter will be included only if it was specified
                               in the request. This is not the default limit enforced
                               by the API.
+                          include_region:
+                            type: string
+                            description: Indicates whether or not to include the IP
+                              address's region. This property will only be returned
+                              if the `include_region` query parameter is included
+                              and set to `true` as part of the API request.
               examples:
                 '200':
                   value:
@@ -1233,6 +1357,7 @@ paths:
       parameters:
       - $ref: '#/components/parameters/IpAddressManagementLimit'
       - $ref: '#/components/parameters/IpAddressManagementAfterKey'
+      - $ref: '#/components/parameters/IpAddressManagementIncludeRegion'
     parameters:
     - $ref: '#/components/parameters/IpAddressManagementPoolId'
   /v3/send_ips/pools/{poolid}/ips:batchAdd:
@@ -1500,8 +1625,8 @@ components:
       required: false
       schema:
         type: string
-      description: Specifices an IP address. The `ip` query parameter can be used
-        to filter results by IP address.
+      description: Specifies an IP address. The `ip` query parameter can be used to
+        filter results by IP address.
     IpAddressManagementBeforeKey:
       name: before_key
       in: query
@@ -1537,8 +1662,10 @@ components:
       required: false
       schema:
         type: boolean
-      description: Indicates if a parent on the account is able to send email from
-        the IP address. When set to `true`, only enabled IP addresses will be returned.
+      description: A parent must be assigned to an IP address before the parent can
+        send mail from the IP and before the address can be assigned to an IP pool.
+        Set this parameter value to true to allow the parent to send mail from the
+        IP and make the IP eligible for IP pool assignment using the IP pool endpoints.
     IpAddressManagementPool:
       name: pool
       in: query
@@ -1565,8 +1692,34 @@ components:
         type: integer
       description: The `start_added_at` and `end_added_at` parameters are used to
         set a time window. IP addresses that were added to your account in the specified
-        time window will be returned. The `start_added_at` parameter sets the end
-        of the time window.
+        time window will be returned. The `end_added_at` parameter sets the end of
+        the time window.
+    IpAddressManagementRegion:
+      name: region
+      in: query
+      required: false
+      description: Allowed values are `all`, `eu`, and `us`. If you provide a specific
+        region, results will include all pools that have at least one IP in the filtered
+        region. If `all`, pools with at least one IP (regardless of region) will be
+        returned. If the `region` filter is not provided, the query returns all pools,
+        including empty ones. (Regional email is in Public Beta and requires SendGrid
+        Pro plan or above.)
+      schema:
+        type: string
+        enum:
+        - all
+        - eu
+        - us
+    IpAddressManagementIncludeRegion:
+      name: include_region
+      in: query
+      required: false
+      description: Boolean indicating whether or not to return the IP Pool's region
+        information in the response. (Regional email is in Public Beta and requires
+        SendGrid Pro plan or above.)
+      schema:
+        type: boolean
+        default: false
   examples:
     IpAddressManagement400PoolIdTypeError:
       value:

--- a/spec/yaml/tsg_link_branding_v3.yaml
+++ b/spec/yaml/tsg_link_branding_v3.yaml
@@ -65,6 +65,15 @@ paths:
                   enum:
                   - true
                   - false
+                region:
+                  type: string
+                  default: us
+                  description: The region of the IP address. Can be `eu` or `us`.
+                    (Regional email is in Public Beta and requires SendGrid Pro plan
+                    or above.)
+                  enum:
+                  - eu
+                  - us
               required:
               - domain
               example:

--- a/spec/yaml/tsg_subusers_v3.yaml
+++ b/spec/yaml/tsg_subusers_v3.yaml
@@ -58,6 +58,28 @@ paths:
           page size is used.'
         schema:
           type: integer
+      - name: region
+        in: query
+        description: Filter for Subusers in this region. If not provided, all Subusers
+          will be returned. All users can also be explicitly requested by using the
+          filter `all`. Users who are not pinned to a region will be displayed as
+          `global`. (Regional email is in Public Beta and requires SendGrid Pro plan
+          or above.)
+        schema:
+          type: string
+          enum:
+          - all
+          - global
+          - eu
+          default: all
+      - name: include_region
+        in: query
+        description: Optional flag to include the regions of the Subusers in the response.
+          If not provided, the region will be omitted from the response. (Regional
+          email is in Public Beta and requires SendGrid Pro plan or above.)
+        schema:
+          type: boolean
+          default: false
       - $ref: '#/components/parameters/PaginationCommonOffset'
       responses:
         '200':
@@ -120,6 +142,21 @@ paths:
                   items:
                     type: string
                     format: ipv4
+                region:
+                  type: string
+                  description: The region this Subuser should be assigned to. Can
+                    be `global` or `eu`. (Regional email is in Public Beta and requires
+                    SendGrid Pro plan or above.).
+                  enum:
+                  - global
+                  - eu
+                  default: global
+                include_region:
+                  type: boolean
+                  description: A flag that determines if the Subuser's region should
+                    be returned in the response. (Regional email is in Public Beta
+                    and requires SendGrid Pro plan or above.)
+                  default: false
               required:
               - username
               - email
@@ -132,6 +169,8 @@ paths:
                 ips:
                 - 1.1.1.1
                 - 2.2.2.2
+                region: global
+                include_region: true
       responses:
         '200':
           description: ''
@@ -1105,6 +1144,14 @@ components:
           type: string
           description: The email address to contact this subuser.
           format: email
+        region:
+          type: string
+          description: The region this Subuser is assigned to. This property is returned
+            only if the `include_region` parameter was included and set to `true`
+            in the API request.
+          enum:
+          - global
+          - eu
       required:
       - disabled
       - id
@@ -1134,6 +1181,15 @@ components:
           properties:
             type:
               type: string
+        region:
+          type: string
+          description: The region this Subuser is assigned to. The property is returned
+            only if the `include_region` parameter is included and set to `true` in
+            the API request.
+          enum:
+          - global
+          - eu
+          default: global
       required:
       - username
       - user_id
@@ -1144,6 +1200,7 @@ components:
         email: example@example.com
         credit_allocation:
           type: unlimited
+        region: global
     SubuserCredits:
       title: Credits of a Subuser
       type: object


### PR DESCRIPTION
This pull request add changes to support regional email functionality. The changes include the addition of a `region` param/property used across the Domain Authentication, IP Address Management, Link Branding, and Subusers APIs.
