### PR TITLE
Add bulk email address validation operations

### DIFF
--- a/spec/json/tsg_email_validation_v3.json
+++ b/spec/json/tsg_email_validation_v3.json
@@ -338,7 +338,7 @@
         "tags": [
           "Bulk Email Address Validation"
         ],
-        "description": "**This endpoint returns a list of all of a user's Bulk Email Validation Jobs.**\n",
+        "description": "**This endpoint returns a list of all of a user's Bulk Email Validation Jobs.**",
         "responses": {
           "200": {
             "description": "The request was successful. The response contains a list of all of your Bulk Email Validation Jobs.",

--- a/spec/yaml/tsg_email_validation_v3.yaml
+++ b/spec/yaml/tsg_email_validation_v3.yaml
@@ -277,9 +277,7 @@ paths:
       tags:
       - Bulk Email Address Validation
       description: '**This endpoint returns a list of all of a user''s Bulk Email
-        Validation Jobs.**
-
-        '
+        Validation Jobs.**'
       responses:
         '200':
           description: The request was successful. The response contains a list of


### PR DESCRIPTION
This pull request introduces new endpoints and schemas related to Bulk Email Address Validation.

Here are the most important changes:

Addition of new endpoints:

* [`/v3/validations/email/jobs`](diffhunk://#diff-fe93501331a6fd2795701c9dc419d5f2db4c8c5e087ac1fbd0781cf4d563ca3bR197-R499): This new endpoint allows for the creation and retrieval of Bulk Email Address Validation jobs. It supports both `PUT` and `GET` operations. The `PUT` operation requests a presigned URL and headers for bulk email address validation list upload, while the `GET` operation lists all of a User's Bulk Email Validation Jobs.
* [`/v3/validations/email/jobs/{job_id}`](diffhunk://#diff-fe93501331a6fd2795701c9dc419d5f2db4c8c5e087ac1fbd0781cf4d563ca3bR197-R499): This new endpoint allows for the retrieval of a specific Bulk Email Validation Job, providing progress details of the job. It supports the `GET` operation.

Addition of new schemas:

* [`PutValidationsEmailJobs200Response`](diffhunk://#diff-fe93501331a6fd2795701c9dc419d5f2db4c8c5e087ac1fbd0781cf4d563ca3bR197-R499): This new schema describes the response for a successful request to create a Bulk Email Address Validation job.
* [`GetValidationsEmailJobs200Response`](diffhunk://#diff-fe93501331a6fd2795701c9dc419d5f2db4c8c5e087ac1fbd0781cf4d563ca3bR197-R499): This new schema describes the response for a successful request to list all Bulk Email Validation Jobs.
* [`GetValidationsEmailJobsJobId200Response`](diffhunk://#diff-fe93501331a6fd2795701c9dc419d5f2db4c8c5e087ac1fbd0781cf4d563ca3bR197-R499): This new schema describes the response for a successful request to retrieve a specific Bulk Email Validation Job.