### PR TITLE
Add Subuser changes to public spec

### DIFF
--- a/spec/json/tsg_domain_authentication_v3.json
+++ b/spec/json/tsg_domain_authentication_v3.json
@@ -436,24 +436,24 @@
       }
     },
     "/v3/whitelabel/domains/{domain_id}/subuser": {
-      "parameters": [
-        {
-          "name": "domain_id",
-          "in": "path",
-          "description": "ID of the authenticated domain to associate with the subuser.",
-          "required": true,
-          "schema": {
-            "type": "integer"
-          }
-        }
-      ],
       "post": {
         "operationId": "PostWhitelabelDomainsDomainIdSubuser",
         "summary": "Associate an authenticated domain with a given user.",
         "tags": [
           "Domain Authentication"
         ],
-        "description": "**This endpoint allows you to associate a specific authenticated domain with a subuser.**\n\nAuthenticated domains can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's domain authentication. To associate an authenticated domain with a subuser, the parent account must first authenticate and validate the domain. The parent may then associate the authenticated domain via the subuser management tools.",
+        "description": "**This endpoint allows you to associate a specific authenticated domain with a subuser.**\nAuthenticated domains can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's domain. To associate an authenticated domain with a subuser, the parent account must first authenticate and validate the domain. The parent may then associate the authenticated domain via the subuser management tools.\n\n\n[You can associate more than one domain with a subuser using the `v3/whitelabel/domains/{domain_id}/subuser:add` endpoint](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/associate-an-authenticated-domain-with-a-subuser-multiple).",
+        "parameters": [
+          {
+            "name": "domain_id",
+            "in": "path",
+            "description": "ID of the authenticated domain to associate with the subuser.",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -489,7 +489,143 @@
                       "id": 1,
                       "domain": "example.com",
                       "subdomain": "mail",
-                      "username": "mail@example.com",
+                      "username": "jdoe",
+                      "user_id": 7,
+                      "ips": [],
+                      "custom_spf": true,
+                      "default": false,
+                      "legacy": false,
+                      "automatic_security": false,
+                      "valid": false,
+                      "dns": {
+                        "mail_server": {
+                          "host": "mail.example.com",
+                          "type": "mx",
+                          "data": "sendgrid.net",
+                          "valid": false
+                        },
+                        "subdomain_spf": {
+                          "host": "mail.example.com",
+                          "type": "txt",
+                          "data": "v=spf1 ip4:192.168.1.1 ip4:192.168.0.1 -all",
+                          "valid": false
+                        },
+                        "domain_spf": {
+                          "host": "example.com",
+                          "type": "txt",
+                          "data": "v=spf1 include:mail.example.com -all",
+                          "valid": false
+                        },
+                        "dkim": {
+                          "host": "s1._domainkey.example.com",
+                          "type": "txt",
+                          "data": "k=rsa; t=s; p=publicKey",
+                          "valid": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DeleteWhitelabelDomainsSubuserMultiple",
+        "summary": "Disassociate an authenticated domain from a given user for users with up to five associated domains.",
+        "tags": [
+          "Domain Authentication"
+        ],
+        "description": "**This endpoint allows you to disassociate a specific authenticated domain from a subuser, for users with up to five associated domains.**\n\n\nThis functionality allows subusers to send mail using their parent's domain. Authenticated domains can be associated with (i.e. assigned to) subusers kknt, and a subuser can have up to five associated authenticated domains. \n\nYou can dissociate an authenticated domain from any subuser that has one or more authenticated domains using this endpoint.",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "Username for the subuser to find associated authenticated domain.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "domain_id",
+            "in": "path",
+            "description": "ID of the authenticated domain to be disassociated with the subuser.",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/whitelabel/domains/{domain_id}/subuser:add": {
+      "parameters": [
+        {
+          "name": "domain_id",
+          "in": "path",
+          "description": "ID of the authenticated domain to associate with the subuser.",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "PostWhitelabelDomainsDomainIdSubuserMultiple",
+        "summary": "Associate an authenticated domain with a given user, for up to five domains.",
+        "tags": [
+          "Domain Authentication"
+        ],
+        "description": "**This endpoint allows you to associate a specific authenticated domain with a subuser. It can be used to associate up to five authenticated domains.**\n\n\nThis functionality allows subusers to send mail using their parent's domain. Authenticated domains can be associated with (i.e. assigned to) subusers from a parent account. To associate an authenticated domain with a subuser, the parent account must first authenticate and validate the domain. The parent may then associate the authenticated domain via the subuser management tools.\n\n\nA subuser can have up to five associated authenticated domains. To see the domains that have already been associated with this user, you can [use the API to list the domains currently associated with the subuser](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/list-the-authenticated-domain-associated-with-a-subuser-multiple).\n\n\nWhen selecting a domain to send email from, SendGrid checks for domains in the following order and chooses the first one that appears in the hierarchy: \n1. Domain assigned by the subuser that matches the email's `From` address domain. \n2. The subuser's default domain. \n3. Domain assigned by the parent user that matches the `From` address domain. \n4. Parent user's default domain. \n5. sendgrid.net",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "description": "Username to associate with the authenticated domain."
+                  }
+                },
+                "required": [
+                  "username"
+                ],
+                "example": {
+                  "username": "jdoe"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticatedDomainSpf"
+                },
+                "examples": {
+                  "response": {
+                    "value": {
+                      "id": 1,
+                      "domain": "example.com",
+                      "subdomain": "mail",
+                      "username": "jdoe",
                       "user_id": 7,
                       "ips": [],
                       "custom_spf": true,
@@ -934,7 +1070,7 @@
         "tags": [
           "Domain Authentication"
         ],
-        "description": "**This endpoint allows you to retrieve all of the authenticated domains that have been assigned to a specific subuser.**\n\nAuthenticated domains can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's domain authentication. To associate an authenticated domain with a subuser, the parent account must first authenticate and validate the domain. The parent may then associate the authenticated domain via the subuser management tools.",
+        "description": "**This endpoint allows you to retrieve all of the authenticated domains that have been assigned to a specific subuser.**\n\nAuthenticated domains can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's domain. To associate an authenticated domain with a subuser, the parent account must first authenticate and validate the domain. The parent may then associate the authenticated domain via the subuser management tools.\n\n\nNote that if you used the [`/v3/whitelabel/domains/{domain_id}/subuser:add` endpoint]( https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/associate-an-authenticated-domain-with-a-subuser-multiple) to add multiple domains to the subuser, you can use the [`/v3/whitelabel/domains/subuser/all` endpoint](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/list-the-authenticated-domain-associated-with-a-subuser-multiple) to list those associated domains.",
         "parameters": [
           {
             "name": "username",
@@ -1008,7 +1144,7 @@
         "tags": [
           "Domain Authentication"
         ],
-        "description": "**This endpoint allows you to disassociate a specific authenticated domain from a subuser.**\n\nAuthenticated domains can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's domain authentication. To associate an authenticated domain with a subuser, the parent account must first authenticate and validate the domain. The parent may then associate the authenticated domain via the subuser management tools.",
+        "description": "**This endpoint allows you to disassociate a specific authenticated domain from a subuser.**\n\nAuthenticated domains can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's domain. To associate an authenticated domain with a subuser, the parent account must first authenticate and validate the domain. The parent may then associate the authenticated domain via the subuser management tools.\n\n\nNote that if you used the [`/v3/whitelabel/domains/{domain_id}/subuser:add` endpoint](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/associate-an-authenticated-domain-with-a-subuser-multiple) to add multiple domains to the subuser, you should use the [`/v3/whitelabel/domains/{domain_id}/subuser` endpoint](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/disassociate-an-authenticated-domain-from-a-subuser-multiple) to disassociate those domains.",
         "parameters": [
           {
             "name": "username",
@@ -1026,6 +1162,118 @@
               "application/json": {
                 "schema": {
                   "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/whitelabel/domains/subuser/all": {
+      "get": {
+        "operationId": "GetWhitelabelDomainsSubuserMultiple",
+        "summary": "List all the authenticated domains associated with the given user.",
+        "tags": [
+          "Domain Authentication"
+        ],
+        "description": "**This endpoint allows you to retrieve all of the authenticated domains that have been assigned to a specific subuser.**\n\n\nThis functionality allows subusers to send mail using their parent's domain. Authenticated domains can be associated with (i.e. assigned to) subusers from a parent account, and a subuser can have up to five associated domains. \n\nTo associate an authenticated domain with a subuser, the parent account must first authenticate and validate the domain. The parent may then associate the authenticated domain via the subuser management tools.\n\n\nWhen selecting a domain to send email from, SendGrid checks for domains in the following order and chooses the first one that appears in the hierarchy: \n1. Domain assigned by the subuser that matches the email's `From` address domain. \n2. The subuser's default domain. \n3. Domain assigned by the parent user that matches the `From` address domain. \n4. Parent user's default domain. \n5. sendgrid.net",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "Username for the subuser to find associated authenticated domains.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/AuthenticatedDomain"
+                      }
+                    ]
+                  }
+                },
+                "examples": {
+                  "response": {
+                    "value": [
+                      {
+                        "id": 1,
+                        "domain": "example.com",
+                        "subdomain": "mail",
+                        "username": "jdoe",
+                        "user_id": 7,
+                        "ips": [],
+                        "custom_spf": true,
+                        "default": false,
+                        "legacy": false,
+                        "automatic_security": false,
+                        "valid": false,
+                        "dns": {
+                          "mail_cname": {
+                            "valid": true,
+                            "type": "cname",
+                            "host": "mail.example.com",
+                            "data": "u7.wl.sendgrid.net"
+                          },
+                          "dkim1": {
+                            "valid": true,
+                            "type": "cname",
+                            "host": "s1._domainkey.example.com",
+                            "data": "s1._domainkey.u7.wl.sendgrid.net"
+                          },
+                          "dkim2": {
+                            "valid": true,
+                            "type": "cname",
+                            "host": "s2._domainkey.example.com",
+                            "data": "s2._domainkey.u7.wl.sendgrid.net"
+                          }
+                        }
+                      },
+                      {
+                        "id": 2,
+                        "domain": "example.com",
+                        "subdomain": "mail2",
+                        "username": "jdoe2",
+                        "user_id": 7,
+                        "ips": [],
+                        "custom_spf": true,
+                        "default": true,
+                        "legacy": false,
+                        "automatic_security": true,
+                        "valid": false,
+                        "dns": {
+                          "mail_cname": {
+                            "valid": true,
+                            "type": "cname",
+                            "host": "mail2.example2.com",
+                            "data": "u7.sgsandbox.net"
+                          },
+                          "dkim1": {
+                            "host": "s1._domainkey.example.com",
+                            "type": "cname",
+                            "data": "s1._domainkey.u7.wl.sgsandbox.net",
+                            "valid": true
+                          },
+                          "dkim2": {
+                            "valid": true,
+                            "type": "cname",
+                            "host": "s2._domainkey.example2.com",
+                            "data": "s2._domainkey.u7.w1.sgsandbox.net"
+                          }
+                        }
+                      }
+                    ]
+                  }
                 }
               }
             }

--- a/spec/yaml/tsg_domain_authentication_v3.yaml
+++ b/spec/yaml/tsg_domain_authentication_v3.yaml
@@ -359,13 +359,6 @@ paths:
               schema:
                 type: object
   /v3/whitelabel/domains/{domain_id}/subuser:
-    parameters:
-    - name: domain_id
-      in: path
-      description: ID of the authenticated domain to associate with the subuser.
-      required: true
-      schema:
-        type: integer
     post:
       operationId: PostWhitelabelDomainsDomainIdSubuser
       summary: Associate an authenticated domain with a given user.
@@ -374,13 +367,23 @@ paths:
       description: '**This endpoint allows you to associate a specific authenticated
         domain with a subuser.**
 
-
         Authenticated domains can be associated with (i.e. assigned to) subusers from
         a parent account. This functionality allows subusers to send mail using their
-        parent''s domain authentication. To associate an authenticated domain with
-        a subuser, the parent account must first authenticate and validate the domain.
-        The parent may then associate the authenticated domain via the subuser management
-        tools.'
+        parent''s domain. To associate an authenticated domain with a subuser, the
+        parent account must first authenticate and validate the domain. The parent
+        may then associate the authenticated domain via the subuser management tools.
+
+
+
+        [You can associate more than one domain with a subuser using the `v3/whitelabel/domains/{domain_id}/subuser:add`
+        endpoint](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/associate-an-authenticated-domain-with-a-subuser-multiple).'
+      parameters:
+      - name: domain_id
+        in: path
+        description: ID of the authenticated domain to associate with the subuser.
+        required: true
+        schema:
+          type: integer
       requestBody:
         content:
           application/json:
@@ -407,7 +410,125 @@ paths:
                     id: 1
                     domain: example.com
                     subdomain: mail
-                    username: mail@example.com
+                    username: jdoe
+                    user_id: 7
+                    ips: []
+                    custom_spf: true
+                    default: false
+                    legacy: false
+                    automatic_security: false
+                    valid: false
+                    dns:
+                      mail_server:
+                        host: mail.example.com
+                        type: mx
+                        data: sendgrid.net
+                        valid: false
+                      subdomain_spf:
+                        host: mail.example.com
+                        type: txt
+                        data: v=spf1 ip4:192.168.1.1 ip4:192.168.0.1 -all
+                        valid: false
+                      domain_spf:
+                        host: example.com
+                        type: txt
+                        data: v=spf1 include:mail.example.com -all
+                        valid: false
+                      dkim:
+                        host: s1._domainkey.example.com
+                        type: txt
+                        data: k=rsa; t=s; p=publicKey
+                        valid: false
+    delete:
+      operationId: DeleteWhitelabelDomainsSubuserMultiple
+      summary: Disassociate an authenticated domain from a given user for users with
+        up to five associated domains.
+      tags:
+      - Domain Authentication
+      description: "**This endpoint allows you to disassociate a specific authenticated\
+        \ domain from a subuser, for users with up to five associated domains.**\n\
+        \n\nThis functionality allows subusers to send mail using their parent's domain.\
+        \ Authenticated domains can be associated with (i.e. assigned to) subusers\
+        \ kknt, and a subuser can have up to five associated authenticated domains.\
+        \ \n\nYou can dissociate an authenticated domain from any subuser that has\
+        \ one or more authenticated domains using this endpoint."
+      parameters:
+      - name: username
+        in: query
+        description: Username for the subuser to find associated authenticated domain.
+        schema:
+          type: string
+      - name: domain_id
+        in: path
+        description: ID of the authenticated domain to be disassociated with the subuser.
+        required: true
+        schema:
+          type: integer
+      responses:
+        '204':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+  /v3/whitelabel/domains/{domain_id}/subuser:add:
+    parameters:
+    - name: domain_id
+      in: path
+      description: ID of the authenticated domain to associate with the subuser.
+      required: true
+      schema:
+        type: integer
+    post:
+      operationId: PostWhitelabelDomainsDomainIdSubuserMultiple
+      summary: Associate an authenticated domain with a given user, for up to five
+        domains.
+      tags:
+      - Domain Authentication
+      description: "**This endpoint allows you to associate a specific authenticated\
+        \ domain with a subuser. It can be used to associate up to five authenticated\
+        \ domains.**\n\n\nThis functionality allows subusers to send mail using their\
+        \ parent's domain. Authenticated domains can be associated with (i.e. assigned\
+        \ to) subusers from a parent account. To associate an authenticated domain\
+        \ with a subuser, the parent account must first authenticate and validate\
+        \ the domain. The parent may then associate the authenticated domain via the\
+        \ subuser management tools.\n\n\nA subuser can have up to five associated\
+        \ authenticated domains. To see the domains that have already been associated\
+        \ with this user, you can [use the API to list the domains currently associated\
+        \ with the subuser](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/list-the-authenticated-domain-associated-with-a-subuser-multiple).\n\
+        \n\nWhen selecting a domain to send email from, SendGrid checks for domains\
+        \ in the following order and chooses the first one that appears in the hierarchy:\
+        \ \n1. Domain assigned by the subuser that matches the email's `From` address\
+        \ domain. \n2. The subuser's default domain. \n3. Domain assigned by the parent\
+        \ user that matches the `From` address domain. \n4. Parent user's default\
+        \ domain. \n5. sendgrid.net"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                  description: Username to associate with the authenticated domain.
+              required:
+              - username
+              example:
+                username: jdoe
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthenticatedDomainSpf'
+              examples:
+                response:
+                  value:
+                    id: 1
+                    domain: example.com
+                    subdomain: mail
+                    username: jdoe
                     user_id: 7
                     ips: []
                     custom_spf: true
@@ -735,10 +856,17 @@ paths:
 
         Authenticated domains can be associated with (i.e. assigned to) subusers from
         a parent account. This functionality allows subusers to send mail using their
-        parent''s domain authentication. To associate an authenticated domain with
-        a subuser, the parent account must first authenticate and validate the domain.
-        The parent may then associate the authenticated domain via the subuser management
-        tools.'
+        parent''s domain. To associate an authenticated domain with a subuser, the
+        parent account must first authenticate and validate the domain. The parent
+        may then associate the authenticated domain via the subuser management tools.
+
+
+
+        Note that if you used the [`/v3/whitelabel/domains/{domain_id}/subuser:add`
+        endpoint]( https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/associate-an-authenticated-domain-with-a-subuser-multiple)
+        to add multiple domains to the subuser, you can use the [`/v3/whitelabel/domains/subuser/all`
+        endpoint](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/list-the-authenticated-domain-associated-with-a-subuser-multiple)
+        to list those associated domains.'
       parameters:
       - name: username
         in: query
@@ -799,10 +927,17 @@ paths:
 
         Authenticated domains can be associated with (i.e. assigned to) subusers from
         a parent account. This functionality allows subusers to send mail using their
-        parent''s domain authentication. To associate an authenticated domain with
-        a subuser, the parent account must first authenticate and validate the domain.
-        The parent may then associate the authenticated domain via the subuser management
-        tools.'
+        parent''s domain. To associate an authenticated domain with a subuser, the
+        parent account must first authenticate and validate the domain. The parent
+        may then associate the authenticated domain via the subuser management tools.
+
+
+
+        Note that if you used the [`/v3/whitelabel/domains/{domain_id}/subuser:add`
+        endpoint](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/associate-an-authenticated-domain-with-a-subuser-multiple)
+        to add multiple domains to the subuser, you should use the [`/v3/whitelabel/domains/{domain_id}/subuser`
+        endpoint](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/disassociate-an-authenticated-domain-from-a-subuser-multiple)
+        to disassociate those domains.'
       parameters:
       - name: username
         in: query
@@ -816,6 +951,99 @@ paths:
             application/json:
               schema:
                 type: object
+  /v3/whitelabel/domains/subuser/all:
+    get:
+      operationId: GetWhitelabelDomainsSubuserMultiple
+      summary: List all the authenticated domains associated with the given user.
+      tags:
+      - Domain Authentication
+      description: "**This endpoint allows you to retrieve all of the authenticated\
+        \ domains that have been assigned to a specific subuser.**\n\n\nThis functionality\
+        \ allows subusers to send mail using their parent's domain. Authenticated\
+        \ domains can be associated with (i.e. assigned to) subusers from a parent\
+        \ account, and a subuser can have up to five associated domains. \n\nTo associate\
+        \ an authenticated domain with a subuser, the parent account must first authenticate\
+        \ and validate the domain. The parent may then associate the authenticated\
+        \ domain via the subuser management tools.\n\n\nWhen selecting a domain to\
+        \ send email from, SendGrid checks for domains in the following order and\
+        \ chooses the first one that appears in the hierarchy: \n1. Domain assigned\
+        \ by the subuser that matches the email's `From` address domain. \n2. The\
+        \ subuser's default domain. \n3. Domain assigned by the parent user that matches\
+        \ the `From` address domain. \n4. Parent user's default domain. \n5. sendgrid.net"
+      parameters:
+      - name: username
+        in: query
+        description: Username for the subuser to find associated authenticated domains.
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  allOf:
+                  - $ref: '#/components/schemas/AuthenticatedDomain'
+              examples:
+                response:
+                  value:
+                  - id: 1
+                    domain: example.com
+                    subdomain: mail
+                    username: jdoe
+                    user_id: 7
+                    ips: []
+                    custom_spf: true
+                    default: false
+                    legacy: false
+                    automatic_security: false
+                    valid: false
+                    dns:
+                      mail_cname:
+                        valid: true
+                        type: cname
+                        host: mail.example.com
+                        data: u7.wl.sendgrid.net
+                      dkim1:
+                        valid: true
+                        type: cname
+                        host: s1._domainkey.example.com
+                        data: s1._domainkey.u7.wl.sendgrid.net
+                      dkim2:
+                        valid: true
+                        type: cname
+                        host: s2._domainkey.example.com
+                        data: s2._domainkey.u7.wl.sendgrid.net
+                  - id: 2
+                    domain: example.com
+                    subdomain: mail2
+                    username: jdoe2
+                    user_id: 7
+                    ips: []
+                    custom_spf: true
+                    default: true
+                    legacy: false
+                    automatic_security: true
+                    valid: false
+                    dns:
+                      mail_cname:
+                        valid: true
+                        type: cname
+                        host: mail2.example2.com
+                        data: u7.sgsandbox.net
+                      dkim1:
+                        host: s1._domainkey.example.com
+                        type: cname
+                        data: s1._domainkey.u7.wl.sgsandbox.net
+                        valid: true
+                      dkim2:
+                        valid: true
+                        type: cname
+                        host: s2._domainkey.example2.com
+                        data: s2._domainkey.u7.w1.sgsandbox.net
 components:
   schemas:
     AuthenticatedDomain:


### PR DESCRIPTION
This pull request includes changes to the `tsg_domain_authentication_v3.json` and `tsg_domain_authentication_v3.yaml` files, primarily focusing on the modification and addition of API endpoints related to domain authentication for subusers. The changes add functionality for associating multiple domains with a subuser and listing all associated domains.

API Endpoints Modification:

* `spec/json/tsg_domain_authentication_v3.json` and `spec/yaml/tsg_domain_authentication_v3.yaml`: The `POST /v3/whitelabel/domains/{domain_id}/subuser` endpoint has been modified to allow associating multiple domains with a subuser. The endpoint's description has been updated to include a reference to a new endpoint for associating multiple domains. [[1]](diffhunk://#diff-a152e9d904aa21e4f35531eeac912d5096345b0563ef16fbf71fd454924d15f4R439-R574) [[2]](diffhunk://#diff-a152e9d904aa21e4f35531eeac912d5096345b0563ef16fbf71fd454924d15f4L451-R592) [[3]](diffhunk://#diff-5a73de2a47b803851982426bf76a6080fa1214a06710c6fe61e3cec84d033717L362-L368) [[4]](diffhunk://#diff-5a73de2a47b803851982426bf76a6080fa1214a06710c6fe61e3cec84d033717L377-R386)

API Endpoints Addition:

* [`spec/json/tsg_domain_authentication_v3.json`](diffhunk://#diff-a152e9d904aa21e4f35531eeac912d5096345b0563ef16fbf71fd454924d15f4R1171-R1282): A new `GET /v3/whitelabel/domains/subuser/all` endpoint has been added. This endpoint allows retrieving all the authenticated domains that have been assigned to a specific subuser.

Other Changes:

* [`spec/json/tsg_domain_authentication_v3.json`](diffhunk://#diff-a152e9d904aa21e4f35531eeac912d5096345b0563ef16fbf71fd454924d15f4L937-R1073): Various changes have been made to the descriptions of existing endpoints to clarify the use of the new functionality for associating multiple domains with a subuser. [[1]](diffhunk://#diff-a152e9d904aa21e4f35531eeac912d5096345b0563ef16fbf71fd454924d15f4L937-R1073) [[2]](diffhunk://#diff-a152e9d904aa21e4f35531eeac912d5096345b0563ef16fbf71fd454924d15f4L1011-R1147)
* [`spec/json/tsg_domain_authentication_v3.json`](diffhunk://#diff-a152e9d904aa21e4f35531eeac912d5096345b0563ef16fbf71fd454924d15f4L492-R628): The example username in the response of the `POST /v3/whitelabel/domains/{domain_id}/subuser:add` endpoint has been changed from `mail@example.com` to `jdoe`.
