### PR TITLE
Add Subusers endpoint

### DIFF
--- a/spec/json/tsg_subusers_v3.json
+++ b/spec/json/tsg_subusers_v3.json
@@ -340,7 +340,7 @@
                 "properties": {
                   "disabled": {
                     "type": "boolean",
-                    "description": "Whether or not this subuser is disabled. True means disabled, False means enabled."
+                    "description": "Whether or not this subuser is disabled. `true` means disabled, `false` means enabled."
                   }
                 },
                 "example": {
@@ -468,6 +468,57 @@
                       ]
                     }
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/subusers/{subuser_name}/website_access": {
+      "parameters": [
+        {
+          "name": "subuser_name",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "patch": {
+        "operationId": "PatchSubusersSubuserNameWebsiteAccess",
+        "summary": "Enable/Disable website access for a Subuser",
+        "tags": [
+          "Subuser Website Access"
+        ],
+        "description": "Enable/Disable website access for a Subuser, while still preserving email send functionality.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "disabled": {
+                    "type": "boolean",
+                    "description": "Whether or not to disable website access to the Subuser. `true` means disabled, `false` means enabled."
+                  }
+                },
+                "example": {
+                  "disabled": true
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
                 }
               }
             }

--- a/spec/yaml/tsg_subusers_v3.yaml
+++ b/spec/yaml/tsg_subusers_v3.yaml
@@ -249,8 +249,8 @@ paths:
               properties:
                 disabled:
                   type: boolean
-                  description: Whether or not this subuser is disabled. True means
-                    disabled, False means enabled.
+                  description: Whether or not this subuser is disabled. `true` means
+                    disabled, `false` means enabled.
               example:
                 disabled: false
       responses:
@@ -325,6 +325,40 @@ paths:
                     errors:
                     - field: null
                       message: authorization required
+  /v3/subusers/{subuser_name}/website_access:
+    parameters:
+    - name: subuser_name
+      in: path
+      required: true
+      schema:
+        type: string
+    patch:
+      operationId: PatchSubusersSubuserNameWebsiteAccess
+      summary: Enable/Disable website access for a Subuser
+      tags:
+      - Subuser Website Access
+      description: Enable/Disable website access for a Subuser, while still preserving
+        email send functionality.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                disabled:
+                  type: boolean
+                  description: Whether or not to disable website access to the Subuser.
+                    `true` means disabled, `false` means enabled.
+              example:
+                disabled: true
+      responses:
+        '204':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
   /v3/subusers/{subuser_name}/credits:
     parameters:
     - $ref: '#/components/parameters/UserName'


### PR DESCRIPTION
This pull request primarily focuses on two key areas: updating the descriptions in the JSON and YAML files to use code formatting for boolean values, and introducing a new API endpoint in both files to control website access for a subuser.

Enhancements to descriptions:

* `spec/json/tsg_subusers_v3.json` and `spec/yaml/tsg_subusers_v3.yaml`: Updated the descriptions for the `disabled` property to use code formatting for boolean values (i.e., `true` and `false`), which improves readability and understanding. [[1]](diffhunk://#diff-0c7ca6104fa06e4547dd35d3e5036897bdd0e01fbde9c269d4553d87367ce790L343-R343) [[2]](diffhunk://#diff-39942d7987223ea015826f511cde0747cb169135ebd8fcc2fdbcbe3348ead88bL252-R253)

Addition of new API endpoint:

* `spec/json/tsg_subusers_v3.json` and `spec/yaml/tsg_subusers_v3.yaml`: Added a new API endpoint (`/v3/subusers/{subuser_name}/website_access`) that allows enabling or disabling website access for a specific subuser while preserving email send functionality. This endpoint uses the `PATCH` method and requires the `subuser_name` as a path parameter. [[1]](diffhunk://#diff-0c7ca6104fa06e4547dd35d3e5036897bdd0e01fbde9c269d4553d87367ce790R478-R528) [[2]](diffhunk://#diff-39942d7987223ea015826f511cde0747cb169135ebd8fcc2fdbcbe3348ead88bR328-R361)