### PR TITLE
Fix contacts API typo

### DIFF
--- a/spec/json/tsg_mc_contacts_v3.json
+++ b/spec/json/tsg_mc_contacts_v3.json
@@ -51,7 +51,7 @@
                   },
                   "contacts": {
                     "type": "array",
-                    "description": "One or more contacts objects that you intend to upsert. Each contact needs to include at least one of `email`, `phone_number`, `external_id`, or `anonymous_id` as an identifier.",
+                    "description": "One or more contacts objects that you intend to upsert. Each contact needs to include at least one of `email`, `phone_number_id`, `external_id`, or `anonymous_id` as an identifier.",
                     "minItems": 1,
                     "maxItems": 30000,
                     "items": {

--- a/spec/yaml/tsg_mc_contacts_v3.yaml
+++ b/spec/yaml/tsg_mc_contacts_v3.yaml
@@ -78,7 +78,7 @@ paths:
                 contacts:
                   type: array
                   description: One or more contacts objects that you intend to upsert.
-                    Each contact needs to include at least one of `email`, `phone_number`,
+                    Each contact needs to include at least one of `email`, `phone_number_id`,
                     `external_id`, or `anonymous_id` as an identifier.
                   minItems: 1
                   maxItems: 30000


### PR DESCRIPTION
This pull request includes changes to the `spec/json/tsg_mc_contacts_v3.json` and `spec/yaml/tsg_mc_contacts_v3.yaml` files. These changes modify the description of the `contacts` object in both files, specifically changing the identifier from `phone_number` to `phone_number_id`.

Changes to the `contacts` object:

* [`spec/json/tsg_mc_contacts_v3.json`](diffhunk://#diff-16612b2e149ef985bfad1f107bfe32e0fcff7e295ca062be8c4c078d311b00c8L54-R54): Changed the description of the `contacts` object. The identifier has been changed from `phone_number` to `phone_number_id`.
* [`spec/yaml/tsg_mc_contacts_v3.yaml`](diffhunk://#diff-b7a706d0f9bbb08029470aa1897fa815b15aa7b3e3087f1f0ce7377e149f7150L81-R81): Updated the description of the `contacts` object in the `paths:` section. The identifier was updated from `phone_number` to `phone_number_id`.